### PR TITLE
password covered, back button added

### DIFF
--- a/src/views/cards/edit.ejs
+++ b/src/views/cards/edit.ejs
@@ -21,6 +21,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary">Update</button>
             </form>
+            <a href="/lists/<%=card.listId%>" class="btn btn-secondary">Back to Recipe list</a>
         </main>
 
         <% include ../static/partials/baseScripts.ejs %>

--- a/src/views/cards/new.ejs
+++ b/src/views/cards/new.ejs
@@ -24,6 +24,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary">Submit</button>
             </form>
+            <a href="/lists/<%=card.listIid%>" class="btn btn-secondary">Back to Recipe list</a>
         </main>
 
         <% include ../static/partials/baseScripts.ejs %>

--- a/src/views/cards/show.ejs
+++ b/src/views/cards/show.ejs
@@ -17,7 +17,7 @@
             </form>
          
             <p><%= card.recipe %></p>
-          
+        <a href="/lists/<%=card.listId%>" class="btn btn-secondary">Back to Recipe list</a>
         </main>
 
         <% include ../static/partials/baseScripts.ejs %>

--- a/src/views/lists/edit.ejs
+++ b/src/views/lists/edit.ejs
@@ -23,6 +23,7 @@
             </div>
             <button type="submit" class="btn btn-primary">Update</button>
         </form>
+        <a href="/lists/<%=list.id%>" class="btn btn-secondary">Back to Recipe list</a>
         </main>
 
         <% include ../static/partials/baseScripts.ejs %>

--- a/src/views/lists/show.ejs
+++ b/src/views/lists/show.ejs
@@ -31,6 +31,7 @@
                     </li>
                 <% }) %>
             </ul>
+            
         </main>
 
         <% include ../static/partials/baseScripts.ejs %>

--- a/src/views/users/sign_up.ejs
+++ b/src/views/users/sign_up.ejs
@@ -22,7 +22,7 @@
 
                 <div class="form-group">
                     <label for="password">Password</label>
-                    <input ty pe="password" class="form-control" name="password" aria-describedby="passwordHelp" placeholder="Enter password">
+                    <input type="password" class="form-control" name="password" aria-describedby="passwordHelp" placeholder="Enter password">
                     <small class="text-muted" id="passwordHelp">password must match confirmation below</small>
                 </div>
 


### PR DESCRIPTION
The password field on the user sign in form was not covered, this was simply a type that wasn't setting the type for that tag. Back button was added to all recipe card views so that a user can easily navigate back to the same recipe list without going back through the full list again